### PR TITLE
Fixed issue with the length of the labels

### DIFF
--- a/pkg/pxc/backup/job.go
+++ b/pkg/pxc/backup/job.go
@@ -15,7 +15,7 @@ func NewJob(cr *api.PerconaXtraDBBackup) *batchv1.Job {
 			Kind:       "Job",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      cr.Spec.PXCCluster + "-xtrabackup." + cr.Name,
+			Name:      genName63(cr),
 			Namespace: cr.Namespace,
 			Labels: map[string]string{
 				"cluster": cr.Spec.PXCCluster,
@@ -25,12 +25,12 @@ func NewJob(cr *api.PerconaXtraDBBackup) *batchv1.Job {
 	}
 }
 
-func JobSpec(spec api.PXCBackupSpec, name string, pxcNode string, sv *api.ServerVersion) batchv1.JobSpec {
+func JobSpec(spec api.PXCBackupSpec, pvcName string, pxcNode string, sv *api.ServerVersion) batchv1.JobSpec {
 	pvc := corev1.Volume{
-		Name: spec.PXCCluster + "-backup-" + name,
+		Name: "xtrabackup",
 	}
 	pvc.PersistentVolumeClaim = &corev1.PersistentVolumeClaimVolumeSource{
-		ClaimName: spec.PXCCluster + volumeNamePostfix + "." + name,
+		ClaimName: pvcName,
 	}
 
 	// if a suitable node hasn't been chosen - try to make a lucky shot.

--- a/pkg/pxc/backup/names.go
+++ b/pkg/pxc/backup/names.go
@@ -1,0 +1,56 @@
+package backup
+
+import (
+	"math/rand"
+	"strings"
+	"time"
+
+	api "github.com/Percona-Lab/percona-xtradb-cluster-operator/pkg/apis/pxc/v1alpha1"
+)
+
+func init() {
+	rand.Seed(time.Now().UnixNano())
+}
+
+const genSymbols = "abcdefghijklmnopqrstuvwxyz1234567890"
+
+func genRandString(ln int) string {
+	b := make([]byte, ln)
+	for i := range b {
+		b[i] = genSymbols[rand.Intn(len(genSymbols))]
+	}
+
+	return string(b)
+}
+
+func genScheduleLabel(sched string) string {
+	r := strings.NewReplacer("*", "N", "/", "E", " ", "_")
+	return r.Replace(sched)
+}
+
+// genName63 generates legit name for backup resources.
+// k8s sets the `job-name` label for the created by job pod.
+// So we have to be sure that job name won't be longer than 63 symbols.
+// Yet the job name has to have some meaningful name which won't be conflicting with other jobs' names.
+func genName63(cr *api.PerconaXtraDBBackup) string {
+	postfix := cr.Name
+	maxNameLen := 16
+	typ, ok := cr.GetLabels()["type"]
+
+	// in case it's not a cron-job we're not sure if the name fits rules
+	// but there is more room for names
+	if !ok || typ != "cron" {
+		maxNameLen = 29
+		if len(postfix) > maxNameLen {
+			postfix = postfix[:maxNameLen]
+		}
+	}
+
+	name := cr.Spec.PXCCluster
+	if len(cr.Spec.PXCCluster) > maxNameLen {
+		name = name[:maxNameLen]
+	}
+	name += "-xb-" + postfix
+
+	return name
+}

--- a/pkg/pxc/backup/volume.go
+++ b/pkg/pxc/backup/volume.go
@@ -10,8 +10,6 @@ import (
 	api "github.com/Percona-Lab/percona-xtradb-cluster-operator/pkg/apis/pxc/v1alpha1"
 )
 
-const volumeNamePostfix = "-backup"
-
 // NewPVC returns the list of PersistentVolumeClaims for the backups
 func NewPVC(cr *api.PerconaXtraDBBackup) *corev1.PersistentVolumeClaim {
 	return &corev1.PersistentVolumeClaim{
@@ -20,7 +18,7 @@ func NewPVC(cr *api.PerconaXtraDBBackup) *corev1.PersistentVolumeClaim {
 			Kind:       "PersistentVolumeClaim",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      cr.Spec.PXCCluster + volumeNamePostfix + "." + cr.Name,
+			Name:      genName63(cr),
 			Namespace: cr.Namespace,
 		},
 	}


### PR DESCRIPTION
Labels in k8s can't be longer than 63 symbols.
It has caused some problems with backup jobs when CR name was too long.