### PR TITLE
version/server.go: Detect openshift 4.0+ clusters

### DIFF
--- a/version/server.go
+++ b/version/server.go
@@ -60,6 +60,14 @@ func GetServer() (*api.ServerVersion, error) {
 		return version, nil
 	}
 
+	// openshift 4.0
+	version.Info, err = probeAPI("/apis/quota.openshift.io", client)
+	if err == nil {
+		version.Platform = api.PlatformOpenshift
+		version.Info.GitVersion = "undefined (v4.0+)"
+		return version, nil
+	}
+
 	// k8s
 	version.Info, err = probeAPI("/version", client)
 	if err == nil {


### PR DESCRIPTION
Currently if running in openshift 4.0+ it assumes the platform is
kubernetes.